### PR TITLE
Links with surrounding quotes

### DIFF
--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -49,6 +49,25 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal "{link: #{link3_result}}", auto_link("{link: #{link3_raw}}")
   end
 
+   def test_auto_link_with_surrounding_quotes
+    link3a_raw = '"http://www.example.com"'
+    link3a_result = "<a href=\"http://www.example.com\">\"http://www.example.com\"</a>"
+    assert_equal link3a_result, auto_link(link3a_raw)
+    assert_equal link3a_result, auto_link(link3a_raw, sanitize: false)
+    link3b_raw = "'http://www.example.com'"
+    link3b_result = "<a href=\"http://www.example.com\">'http://www.example.com'</a>"
+    assert_equal link3b_result, auto_link(link3b_raw)
+    assert_equal link3b_result, auto_link(link3b_raw, sanitize: false)
+    link3c_raw = "\"http://www.example.com\""
+    link3c_result = "<a href=\"http://www.example.com\">\"http://www.example.com\"</a>"
+    assert_equal link3c_result, auto_link(link3c_raw)
+    assert_equal link3c_result, auto_link(link3c_raw, sanitize: false)
+    link3d_raw = 'other text with "quotes" and a link "http://www.example.com"'
+    link3d_result = "other text with \"quotes\" and a link <a href=\"http://www.example.com\">\"http://www.example.com\"</a>"
+    assert_equal link3d_result, auto_link(link3d_raw)
+    assert_equal link3d_result, auto_link(link3d_raw, sanitize: false)
+  end
+
   def test_auto_link_with_options_hash
     assert_dom_equal 'Welcome to my new blog at <a href="http://www.myblog.com/" class="menu" target="_blank">http://www.myblog.com/</a>. Please e-mail me at <a href="mailto:me@email.com" class="menu" target="_blank">me@email.com</a>.',
       auto_link("Welcome to my new blog at http://www.myblog.com/. Please e-mail me at me@email.com.",


### PR DESCRIPTION
Hi,
One of my users reported a problem with links that are surrounded by quotes.  His example was input
our $HTTP_ATT_TEST_URL ="https://blah.blah.com"
which,  are running through auto_link, was displayed as
our $HTTP_ATT_TEST_URL ="https://blah.blah.com";;

The app is running rails 3.0.7.

Using Rails 3.1.0 and rails_autolink 1.0.2, console testing gives

```
> helper.auto_link "www.example.com"
 => "<a href=\"http://www.example.com\">www.example.com</a>" 
 > helper.auto_link '"www.example.com"'
 => "\"<a href=\"http://www.example.com\">www.example.com</a>&quot;" 
```

(note the second example may be a bit  hard to see here, but it has embedded quotes => ' "www.example.com" '
I think the result of the second example should be

```
"<a href=\"http://www.example.com\">\"www.example.com\"</a>, (ie,  the surrounding quotes only around the link text)
```

If you agree,  this pull request causes the surrounding quotes to show as I expect and doesn't seem to break any of the other tests.

Thanks 

edit:  trying to clean up the formatting
