### PR TITLE
Play nicely with non-latin characters in autolinked urls

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module RailsAutolink
   require 'active_support/core_ext/object/blank'
   require 'active_support/core_ext/array/extract_options'
@@ -80,6 +82,8 @@ module RailsAutolink
 
           BRACKETS = { ']' => '[', ')' => '(', '}' => '{' }
 
+          WORD_PATTERN = RUBY_VERSION < '1.9' ? '\w' : '\p{Word}'
+
           # Turns all urls into clickable links.  If a block is given, each url
           # is yielded and the result is used as the link text.
           def auto_link_urls(text, html_options = {}, options = {})
@@ -93,7 +97,7 @@ module RailsAutolink
                 href
               else
                 # don't include trailing punctuation character as part of the URL
-                while href.sub!(/[^\w\/-]$/, '')
+                while href.sub!(/[^#{WORD_PATTERN}\/-]$/, '')
                   punctuation.push $&
                   if opening = BRACKETS[punctuation.last] and href.scan(opening).size > href.scan(punctuation.last).size
                     href << punctuation.pop

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -298,6 +298,7 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
       http://connect.oraclecorp.com/search?search[q]=green+france&search[type]=Group
       http://of.openfoundry.org/projects/492/download#4th.Release.3
       http://maps.google.co.uk/maps?f=q&q=the+london+eye&ie=UTF8&ll=51.503373,-0.11939&spn=0.007052,0.012767&z=16&iwloc=A
+      http://около.кола/колокола
     )
 
     urls.each do |url|


### PR DESCRIPTION
Given a URL that includes trailing non-latin word characters, those characters will be stripped off by the current implementation, because they do not match "\w".

This pull request uses "\p{Word}" instead of "\w" so that all unicode word characters will match, and will be preserved in the autolinked URL.
