### PR TITLE
allow mixed case protocol specifications

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -15,7 +15,7 @@ module RailsAutolink
         # <tt>:email_addresses</tt>, and <tt>:urls</tt>. If a block is given, each URL and
         # e-mail address is yielded and the result is used as the link text. By default the
         # text given is sanitized, you can override this behaviour setting the
-        # <tt>:sanitize</tt> option to false, or you can add options to the sanitization of 
+        # <tt>:sanitize</tt> option to false, or you can add options to the sanitization of
         # the text using the <tt>:sanitize_options</tt> option hash.
         #
         # ==== Examples
@@ -73,7 +73,7 @@ module RailsAutolink
           AUTO_LINK_RE = %r{
               (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs):)// | www\. )
               [^\s<]+
-            }x
+            }ix
 
           # regexps for determining context, used high-volume
           AUTO_LINK_CRE = [/<[^>]+$/, /^[^>]*>/, /<a\b.*?>/i, /<\/a>/i]

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -88,17 +88,17 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal %{<a href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a>}, auto_link("#{link_raw}#{malicious_script}")
     assert auto_link("#{link_raw}#{malicious_script}").html_safe?
   end
-  
+
   def test_auto_link_should_sanitize_input_with_sanitize_options
     link_raw     = %{http://www.rubyonrails.com?id=1&num=2}
     malicious_script  = '<script>alert("malicious!")</script>'
     text_with_attributes = %{<a href="http://ruby-lang-org" target="_blank" data-malicious="inject">Ruby</a>}
-    
+
     text_result = %{<a class="big" href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a><a href="http://ruby-lang-org" target="_blank">Ruby</a>}
     assert_equal text_result, auto_link("#{link_raw}#{malicious_script}#{text_with_attributes}",
                                         :sanitize_options => {:attributes => ["target", "href"]},
                                         :html => {:class => 'big'})
-    
+
     assert auto_link("#{link_raw}#{malicious_script}#{text_with_attributes}",
                      :sanitize_options => {:attributes => ["target", "href"]},
                      :html => {:class => 'big'}).html_safe?
@@ -107,7 +107,7 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
   def test_auto_link_should_not_sanitize_input_when_sanitize_option_is_false
     link_raw     = %{http://www.rubyonrails.com?id=1&num=2}
     malicious_script  = '<script>alert("malicious!")</script>'
-    
+
     assert_equal %{<a href="http://www.rubyonrails.com?id=1&num=2">http://www.rubyonrails.com?id=1&num=2</a><script>alert("malicious!")</script>}, auto_link("#{link_raw}#{malicious_script}", :sanitize => false)
     assert !auto_link("#{link_raw}#{malicious_script}", :sanitize => false).html_safe?
   end
@@ -156,14 +156,14 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     email_raw         = 'santiago@wyeworks.com'
     link_raw          = 'http://www.rubyonrails.org'
     malicious_script  = '<script>alert("malicious!")</script>'
-    
+
     assert auto_link(nil).html_safe?, 'should be html safe'
     assert auto_link('').html_safe?, 'should be html safe'
     assert auto_link("#{link_raw} #{link_raw} #{link_raw}").html_safe?, 'should be html safe'
     assert auto_link("hello #{email_raw}").html_safe?, 'should be html safe'
     assert auto_link("hello #{email_raw} #{malicious_script}").html_safe?, 'should be html safe'
   end
-  
+
   def test_auto_link_should_not_be_html_safe_when_sanitize_option_false
     email_raw         = 'santiago@wyeworks.com'
     link_raw          = 'http://www.rubyonrails.org'
@@ -177,6 +177,11 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     email_raw    = 'aaron@tenderlovemaking.com'
     email_result = %{<a href="mailto:#{email_raw}">#{email_raw}</a>}
     assert !auto_link_email_addresses(email_result).html_safe?, 'should not be html safe'
+  end
+
+  def test_auto_link_with_bogative_case
+    link_text = "HTTP://youtube.com"
+    assert_equal generate_result(link_text), auto_link(link_text)
   end
 
   def test_auto_link


### PR DESCRIPTION
They're not pretty (HTTP://google.com) but should probably be expected to work, since you can curl them or use them in a browser. Not sure what everyone else might think on this point - but here's a pull request in case you think it should be supported. 

In my case, I have a source of data that often uses uppercase protocols in the text I want to autolink. Of course, I could explicitly intervene and downcase, but I don't think my code should be doing any transformation on the source material.

EDIT: I can see now that github markdown also handles mixed case ;-)
