### PR TITLE
Consider latin1 non-breaking spaces (aka &160;) as spaces, and omit them from autolinked urls

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -72,7 +72,7 @@ module RailsAutolink
 
           AUTO_LINK_RE = %r{
               (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
-              [^\s<]+
+              [^\s<\u00A0]+
             }x
 
           # regexps for determining context, used high-volume

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -266,6 +266,10 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     with_kcode 'u' do
       assert_equal %(浅草.rbの公式サイトはこちら#{link11_result}), auto_link("浅草.rbの公式サイトはこちら#{link11_raw}")
     end
+
+    link12_raw    = 'http://tools.ietf.org/html/rfc3986'
+    link12_result = generate_result(link12_raw)
+    assert_equal %(<p>#{link12_result} text-after-nonbreaking-space</p>), auto_link("<p>#{link12_raw} text-after-nonbreaking-space</p>")
   end
 
   def test_auto_link_parsing


### PR DESCRIPTION
The non-breaking space (`0xA0`, `&160;`, ` `) doesn't get counted as a space currently. 

Before patch: 

``` ruby
> helper.auto_link("http://github.com is great")
=> "<a href=\"http://github.com is\">http://github.com is</a> great" 
```

After patch:

``` ruby
> helper.auto_link("http://github.com is great")
=> "<a href=\"http://github.com\">http://github.com</a> is great" 
```
