### PR TITLE
Improved email regex to allow especial chars

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -78,7 +78,8 @@ module RailsAutolink
           # regexps for determining context, used high-volume
           AUTO_LINK_CRE = [/<[^>]+$/, /^[^>]*>/, /<a\b.*?>/i, /<\/a>/i]
 
-          AUTO_EMAIL_RE = /[\w.!#\$%+-]+@[\w-]+(?:\.[\w-]+)+/
+          AUTO_EMAIL_LOCAL_RE = /[\w.!#\$%&'*\/=?^`{|}~+-]/
+          AUTO_EMAIL_RE = /[\w.!#\$%+-]\.?(?:#{AUTO_EMAIL_LOCAL_RE}+\.)*#{AUTO_EMAIL_LOCAL_RE}*@[\w-]+(?:\.[\w-]+)+/
 
           BRACKETS = { ']' => '[', ')' => '(', '}' => '{' }
 

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -173,6 +173,14 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert !auto_link_email_addresses(email_result).html_safe?, 'should not be html safe'
   end
 
+  def test_auto_link_email_addres_with_especial_chars
+    email_raw    = "and&re$la*+r-a.o'rea=l~ly@tenderlovemaking.com"
+    email_sanitized = "and&amp;re$la*+r-a.o&#39;rea=l~ly@tenderlovemaking.com"
+    email_result = %{<a href="mailto:#{email_raw}">#{email_sanitized}</a>}
+    assert_equal email_result, auto_link(email_raw)
+    assert !auto_link_email_addresses(email_result).html_safe?, 'should not be html safe'
+  end
+
   def test_auto_link
     email_raw    = 'david@loudthinking.com'
     email_result = %{<a href="mailto:#{email_raw}">#{email_raw}</a>}


### PR DESCRIPTION
As is defined in RFC 5322 (http://tools.ietf.org/html/rfc5322)  and RFC 6531 (http://tools.ietf.org/html/rfc6531) some especial chars are allowed in email addresses
- [x] Characters !#$%&'*+-/=?^_`{|}~ (ASCII: 33, 35–39, 42, 43, 45, 47, 61, 63, 94–96, 123–126)
- [x] Character . (dot, period, full stop) (ASCII: 46)
## TODO
- [ ] Special characters are allowed with restrictions. They are:
  - Space and "(),:;<>@[] (ASCII: 32, 34, 40, 41, 44, 58, 59, 60, 62, 64, 91–93)

```
The restrictions for special characters are that they must only be used when contained between quotation marks, and that 2 of them (the backslash \ and quotation mark " (ASCII: 92, 34)) must also be preceded by a backslash \ (e.g. "\\\"").
```
- [ ] Comments are allowed with parentheses at either end of the local part; e.g. "john.smith(comment)@example.com" and "(comment)john.smith@example.com" are both equivalent to "john.smith@example.com".
- [ ] International characters above U+007F are permitted by RFC 6531, though mail systems may restrict which characters to use when assigning local parts.
