### PR TITLE
Fix the email regexp CPU usage for odd inputs

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -79,7 +79,7 @@ module RailsAutolink
           AUTO_LINK_CRE = [/<[^>]+$/, /^[^>]*>/, /<a\b.*?>/i, /<\/a>/i]
 
           AUTO_EMAIL_LOCAL_RE = /[\w.!#\$%&'*\/=?^`{|}~+-]/
-          AUTO_EMAIL_RE = /[\w.!#\$%+-]\.?(?:#{AUTO_EMAIL_LOCAL_RE}+\.)*#{AUTO_EMAIL_LOCAL_RE}*@[\w-]+(?:\.[\w-]+)+/
+          AUTO_EMAIL_RE = /[\w.!#\$%+-]\.?#{AUTO_EMAIL_LOCAL_RE}*@[\w-]+(?:\.[\w-]+)+/
 
           BRACKETS = { ']' => '[', ')' => '(', '}' => '{' }
 

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -309,6 +309,20 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     end
   end
 
+  def test_auto_link_does_not_timeout_when_parsing_odd_email_input
+    inputs = %w(
+      foo@...................................
+      foo@........................................
+      foo@.............................................
+    )
+
+    inputs.each do |input|
+      Timeout.timeout(0.2) do
+        assert_equal input, auto_link(input)
+      end
+    end
+  end
+
   private
   def generate_result(link_text, href = nil, escape = false)
     href ||= link_text


### PR DESCRIPTION
Fixes #34

Some inputs could make the regexp engine in Ruby take up a lot of CPU time in order to check for a match of an email in the input string. This change adds a test to guard against an example of such an input and changes the email regexp so that all the tests pass and so that no excessive CPU usage occurs.

The new email regexp is based on the [changes suggested](https://github.com/tenderlove/rails_autolink/issues/34#issuecomment-26795839) by @andresbravog in #34 but is changed a bit so that tests pass.
