### PR TITLE
require timeout in tests

### DIFF
--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -16,6 +16,7 @@ require 'active_support/core_ext/string/encoding'
 require 'action_dispatch/testing/assertions'
 require 'action_view/helpers/text_helper'
 require 'action_view/helpers/output_safety_helper'
+require 'timeout'
 
 class TestRailsAutolink < MiniTest::Unit::TestCase
   include ActionView::Helpers::CaptureHelper


### PR DESCRIPTION
When running "`testrb test/test_rails_autolink.rb`", the test suite fails:

`NameError: uninitialized constant TestRailsAutolink::Timeout`

Explicitly load the timeout gem during the tests to fix this error.
