### PR TITLE
Fixed XSS issue with link attributes

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -72,7 +72,7 @@ module RailsAutolink
 
           AUTO_LINK_RE = %r{
               (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
-              [^\s<\u00A0]+
+              [^\s<\u00A0"]+
             }ix
 
           # regexps for determining context, used high-volume

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -138,6 +138,14 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal linked_email, auto_link(linked_email)
   end
 
+  def test_auto_link_with_malicious_attr
+    url1 = "http://api.rubyonrails.com/Foo.html"
+    malicious = "\"onmousemove=\"prompt()"
+    combination = "#{url1}#{malicious}"
+
+    assert_equal %(<p><a href="#{url1}">#{url1}</a>#{malicious}</p>), auto_link("<p>#{combination}</p>")
+  end
+
   def test_auto_link_at_eol
     url1 = "http://api.rubyonrails.com/Foo.html"
     url2 = "http://www.ruby-doc.org/core/Bar.html"


### PR DESCRIPTION
The current version of auto_link is vulnerable to a XSS attack:

```
https://www.foobar.com/"onmouseover="prompt()
```

you will get

```
<a href="https://www.foobar.com/" onmouseover="prompt()">https://www.foobar.com/"onmouseover="prompt()</a>
```

**Solution:**

The regexp should find characters until a `"` is found. Then the result is:

```
<a href="https://www.foobar.com/">https://www.foobar.com/"onmouseover="prompt()</a>onmouseover="prompt()"
```
