### PR TITLE
tests: switch to Minitest 5

### DIFF
--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -13,7 +13,7 @@ require 'action_dispatch/testing/assertions'
 require 'timeout'
 require "rails_autolink/helpers"
 
-class TestRailsAutolink < MiniTest::Unit::TestCase
+class TestRailsAutolink < Minitest::Test
   include ActionView::Helpers::CaptureHelper
   include ActionView::Helpers::TextHelper
   include ActionView::Helpers::SanitizeHelper


### PR DESCRIPTION
`MiniTest::Unit::TestCase` is now `Minitest::Test`. Update to the latest Minitest 5 API.
