### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # To test on latest Rails release, use the following:
 gem 'rails'
 gem 'minitest'
+gem 'rails-dom-testing'
 
 # To test on Rails 4.0.x release, use the following e.g. for 4.0.1:
 # gem 'rails', '= 4.0.1'

--- a/rails_autolink.gemspec
+++ b/rails_autolink.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary =  'Automatic generation of html links in texts'
   s.description = 'This is an extraction of the `auto_link` method from rails. The `auto_link` method was removed from Rails in version Rails 3.1. This gem is meant to bridge the gap for people migrating.'
 
-  s.add_dependency 'rails', '> 3.1'
+  s.add_dependency 'railties', '> 3.1'
   s.required_ruby_version = '>= 1.9.3'
   s.license = 'MIT'
 

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -20,7 +20,7 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::OutputSafetyHelper
-  include ActionDispatch::Assertions::DomAssertions
+  include Rails::Dom::Testing::Assertions
 
   def test_auto_link_within_tags
     link_raw    = 'http://www.rubyonrails.org/images/rails.png'


### PR DESCRIPTION
... so that we don't depend on all gems rails depends on (e.g. activerecord) for apps who don't need it.
