### PR TITLE
Aww test

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -71,7 +71,7 @@ module RailsAutolink
         private
 
           AUTO_LINK_RE = %r{
-              (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
+              (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)\/\/ | www\.\w )
               [^\s<\u00A0"]+
             }ix
 

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -20,6 +20,7 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::OutputSafetyHelper
+  include ActionDispatch::Assertions::DomAssertions
 
   def test_auto_link_within_tags
     link_raw    = 'http://www.rubyonrails.org/images/rails.png'

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -20,7 +20,6 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::OutputSafetyHelper
-  include ActionDispatch::Assertions::DomAssertions
 
   def test_auto_link_within_tags
     link_raw    = 'http://www.rubyonrails.org/images/rails.png'
@@ -342,6 +341,27 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
         assert_equal input, auto_link(input)
       end
     end
+  end
+
+  def test_auto_link_does_not_parse_aww
+    inputs = %w(
+      aw...
+      aww
+      aww.
+      aww..
+      awww...
+      awwww.
+      )
+    inputs.each do |input|
+      Timeout.timeout(0.2) do
+        assert_equal input, auto_link(input)
+      end
+    end
+  end
+
+  def test_auto_link_fails_with_aww
+    input = "aww..."
+    assert_equal generate_result(input), auto_link(input)
   end
 
   private


### PR DESCRIPTION
Here's the failing (and the passing) test for "aww.."
Was really an easy fix, just had to add \w somewhere in the middle of the regex.
This should fix the issue.
