### PR TITLE
Avoid another pathological input

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -79,7 +79,7 @@ module RailsAutolink
           AUTO_LINK_CRE = [/<[^>]+$/, /^[^>]*>/, /<a\b.*?>/i, /<\/a>/i]
 
           AUTO_EMAIL_LOCAL_RE = /[\w.!#\$%&'*\/=?^`{|}~+-]/
-          AUTO_EMAIL_RE = /[\w.!#\$%+-]\.?#{AUTO_EMAIL_LOCAL_RE}*@[\w-]+(?:\.[\w-]+)+/
+          AUTO_EMAIL_RE = /(?<!#{AUTO_EMAIL_LOCAL_RE})[\w.!#\$%+-]\.?#{AUTO_EMAIL_LOCAL_RE}*@[\w-]+(?:\.[\w-]+)+/
 
           BRACKETS = { ']' => '[', ')' => '(', '}' => '{' }
 

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -331,10 +331,12 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
   end
 
   def test_auto_link_does_not_timeout_when_parsing_odd_email_input
-    inputs = %w(
+    inputs = %W(
       foo@...................................
       foo@........................................
       foo@.............................................
+
+      #{'foo' * 20000}@
     )
 
     inputs.each do |input|


### PR DESCRIPTION
If we failed to find a valid email address starting from the first valid-local-part character in a sequence, there's no need to try from the second.