### PR TITLE
Allow trailing dashes in URLs (Fixes #52)

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,7 @@
+=== 1.1.7 / 2016-05-31
+
+* Allow trailing dashes in URLs #52
+
 === 1.1.6 / 2014-06-08
 
 * Fixed a potential XSS vulnerability #47

--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -98,7 +98,7 @@ module RailsAutolink
                 href
               else
                 # don't include trailing punctuation character as part of the URL
-                while href.sub!(/[^#{WORD_PATTERN}\/-=&]$/, '')
+                while href.sub!(/[^#{WORD_PATTERN}\/=&]$/, '')
                   punctuation.push $&
                   if opening = BRACKETS[punctuation.last] and href.scan(opening).size > href.scan(punctuation.last).size
                     href << punctuation.pop

--- a/lib/rails_autolink/version.rb
+++ b/lib/rails_autolink/version.rb
@@ -1,3 +1,3 @@
 module RailsAutolink
-  VERSION = '1.1.6'
+  VERSION = '1.1.7'
 end


### PR DESCRIPTION
Here is an example of a Link with a trailing dash. Without the dash, the link is not working.

> https://www.theguardian.com/business/2016/mar/20/co-living-companies-reinventing-roommates-open-door-common-

This fixes #52.