### PR TITLE
Treat trailing dashes as part of the URL (Fixes #52)

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -98,7 +98,7 @@ module RailsAutolink
                 href
               else
                 # don't include trailing punctuation character as part of the URL
-                while href.sub!(/[^#{WORD_PATTERN}\/-=&]$/, '')
+                while href.sub!(/[^#{WORD_PATTERN}\/-=&\-]$/, '')
                   punctuation.push $&
                   if opening = BRACKETS[punctuation.last] and href.scan(opening).size > href.scan(punctuation.last).size
                     href << punctuation.pop

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -330,6 +330,14 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal generate_result(url), auto_link(url)
   end
 
+  def test_autolink_with_trailing_dash_on_link
+    url = "http://www.rubyonrails.com/foo-"
+    assert_equal generate_result(url), auto_link(url)
+
+    expected_result_with_ruby20 = "<a href=\"http://www.rubyonrails.com/foo-\">http://www.rubyonrails.com/foo-</a>"
+    assert_equal expected_result_with_ruby20, auto_link(url)
+  end
+
   def test_auto_link_does_not_timeout_when_parsing_odd_email_input
     inputs = %W(
       foo@...................................


### PR DESCRIPTION
Here is an example of a Link with a trailing dash. Without the dash, the link is not working.

> https://www.theguardian.com/business/2016/mar/20/co-living-companies-reinventing-roommates-open-door-common-

This fixes #52.
