### PR TITLE
Include trailing hyphens in URL

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -98,7 +98,7 @@ module RailsAutolink
                 href
               else
                 # don't include trailing punctuation character as part of the URL
-                while href.sub!(/[^#{WORD_PATTERN}\/-=&]$/, '')
+                while href.sub!(/[^#{WORD_PATTERN}\/-=&\-]$/, '')
                   punctuation.push $&
                   if opening = BRACKETS[punctuation.last] and href.scan(opening).size > href.scan(punctuation.last).size
                     href << punctuation.pop

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -330,6 +330,11 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal generate_result(url), auto_link(url)
   end
 
+  def test_autolink_with_trailing_hyphen_on_link
+    url = "http://www.rubyonrails.com/foo.cgi?trailing_ampersand=value-"
+    assert_equal generate_result(url), auto_link(url)
+  end
+
   def test_auto_link_does_not_timeout_when_parsing_odd_email_input
     inputs = %W(
       foo@...................................


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/tenderlove/rails_autolink/issues/52 bu include trailing hyphens in URL.

## Why

It's valid to have URLs that ends with a `-`. The behaviour before this PR is to exclude it from the part that is auto linked.

## How

We're adding `-` to the list of characters to not treat as a trailing punctuation.

Before this commit

http://www.rubyonrails.com/foo.cgi?trailing_ampersand=value-

Would generate

```html
<a href=\"http://www.rubyonrails.com/foo.cgi?trailing_ampersand=value\">http://www.rubyonrails.com/foo.cgi?trailing_ampersand=value</a>-
```

Instead of

```html
<a href=\"http://www.rubyonrails.com/foo.cgi?trailing_ampersand=value-\”>http://www.rubyonrails.com/foo.cgi?trailing_ampersand=value-</a>
```

## Review notes

Note that this branch has failing tests under rails 7. These have been addressed in a seperate PR to make the review effort easier https://github.com/tenderlove/rails_autolink/pull/72. If #72 is merged before this one all tests in this branch should be green under Rails 7.