### PR TITLE
Include trailing hyphens in URL

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -98,7 +98,7 @@ module RailsAutolink
                 href
               else
                 # don't include trailing punctuation character as part of the URL
-                while href.sub!(/[^#{WORD_PATTERN}\/-=&]$/, '')
+                while href.sub!(/[^#{WORD_PATTERN}\/\-=;]$/, '')
                   punctuation.push $&
                   if opening = BRACKETS[punctuation.last] and href.scan(opening).size > href.scan(punctuation.last).size
                     href << punctuation.pop

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -332,6 +332,28 @@ class TestRailsAutolink < Minitest::Test
     assert_equal generate_result(url), auto_link(url)
   end
 
+  def test_autolink_with_trailing_colon_on_link
+    url = "http://www.rubyonrails.com/foo.cgi?trailing_colon=value:"
+    expected_url = "http://www.rubyonrails.com/foo.cgi?trailing_colon=value"
+
+    assert_equal "#{generate_result(expected_url)}:", auto_link(url)
+  end
+
+  def test_autolink_with_trailing_hyphen_on_link
+    url = "http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value-"
+    assert_equal generate_result(url), auto_link(url)
+  end
+
+  def test_autolink_with_trailing_forward_slash_on_link
+    url = "http://www.rubyonrails.com/foo.cgi?trailing_forward_slash=value/"
+    assert_equal generate_result(url), auto_link(url)
+  end
+
+  def test_autolink_with_trailing_number_on_link
+    url = "http://www.rubyonrails.com/foo.cgi?trailing_number=value3"
+    assert_equal generate_result(url), auto_link(url)
+  end
+
   def test_auto_link_does_not_timeout_when_parsing_odd_email_input
     inputs = %W(
       foo@...................................


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/tenderlove/rails_autolink/issues/52 by including trailing hyphens in URL.

## Why

It's valid to have URLs that ends with a `-`. The behaviour before this PR is to exclude it from the part that is auto linked.

## How

Before this commit

```
http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value-
```

Would generate

```html
<a href=\"[http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value\">http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value</a>-](http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value\)
```

Instead of

```html
<a href=\"[http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value-\">http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value-</a>](http://www.rubyonrails.com/foo.cgi?trailing_hyphen=value-\%E2%80%9D%3Ehttp://www.rubyonrails.com/foo.cgi?trailing_hyphen=value-%3C/a%3E)
```

The reason this was failing was because the unescaped `-` acted as a character class (specifying a range of characters to match, rather than matching against the literal hyphen character has pointed out [here](https://github.com/tenderlove/rails_autolink/pull/45#issuecomment-1209691944)). The previously matched characters were:

```
= & ; : / <
```

`=` and `&` already had specific test cases.

`test_autolink_with_trailing_amp_on_link` was failing when we escape the hyphen (because `&` is turned into `&amp;` and because of that we rely on `;` being included in the URL.

`/` was already explicitly included in the pattern but was not explicitly tested.

`>` is not a problem as it’s escaped to `&lt;`.

Including `:` has been [identified](https://github.com/tenderlove/rails_autolink/pull/45#issuecomment-1209691944) as a regression so we add a test to document that a trailing `:` is no longer being part of the URL.