### PR TITLE
Require a word part after “www.” when auto linking

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -71,7 +71,7 @@ module RailsAutolink
         private
 
           AUTO_LINK_RE = %r{
-              (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
+              (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\.\w )
               [^\s<\u00A0"]+
             }ix
 

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -315,6 +315,7 @@ class TestRailsAutolink < Minitest::Test
       http://of.openfoundry.org/projects/492/download#4th.Release.3
       http://maps.google.co.uk/maps?f=q&q=the+london+eye&ie=UTF8&ll=51.503373,-0.11939&spn=0.007052,0.012767&z=16&iwloc=A
       http://около.кола/колокола
+      https://123domain.com https://123.com https://123.domain.com https://www.123.domain.com
     )
 
     urls.each do |url|
@@ -368,6 +369,10 @@ class TestRailsAutolink < Minitest::Test
         assert_equal input, auto_link(input)
       end
     end
+  end
+
+  def test_auto_link_with_www_in_non_url_string
+    assert_equal "awww.", auto_link("awww.")
   end
 
   private


### PR DESCRIPTION
This is to not parse things like “awww... what a cute kitten” as a link.

Credits to @ItsYou who proposed the solution to issue #46 back in 2015. This commit slims down the tests a bit, leaves out the unnecessary forward-slash escapes (since we're using `%r{}`) and add regression test for numeric domain but is otherwise the same as PR #58.