### PR TITLE
Remove unneeded files from the gem package

### DIFF
--- a/rails_autolink.gemspec
+++ b/rails_autolink.gemspec
@@ -17,5 +17,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.license = 'MIT'
 
-  s.files = Dir.glob("{test,lib/**/*}") + `git ls-files -z`.split("\0")
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |file|
+      file.start_with?('lib', 'CHANGELOG', 'LICENSE', 'README')
+    end
+  end
 end


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from 14K to 8.5K.

<details><summary>gem contents diff</summary>

```patch
< .autotest
< .github/workflows/test.yml
< .gitignore
  CHANGELOG.rdoc
< Gemfile
  README.rdoc
< Rakefile
  lib/rails_autolink.rb
  lib/rails_autolink/helpers.rb
  lib/rails_autolink/version.rb
< rails_autolink.gemspec
< test/test_rails_autolink.rb
```

</details>