### PR TITLE
Don’t include trailing &gt; in auto linked URL

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -92,6 +92,7 @@ module RailsAutolink
             text.gsub(AUTO_LINK_RE) do
               scheme, href = $1, $&
               punctuation = []
+              trailing_gt = ""
 
               if auto_linked?($`, $')
                 # do not change string; URL is already linked
@@ -106,6 +107,9 @@ module RailsAutolink
                   end
                 end
 
+                # don't include trailing &gt; entities as part of the URL
+                trailing_gt = $& if href.sub!(/&gt;$/, '')
+
                 link_text = block_given?? yield(href) : href
                 href = 'http://' + href unless scheme
 
@@ -113,7 +117,7 @@ module RailsAutolink
                   link_text = sanitize(link_text)
                   href      = sanitize(href)
                 end
-                content_tag(:a, link_text, link_attributes.merge('href' => href), !!options[:sanitize]) + punctuation.reverse.join('')
+                content_tag(:a, link_text, link_attributes.merge('href' => href), !!options[:sanitize]) + punctuation.reverse.join('') + trailing_gt.html_safe
               end
             end
           end

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -42,6 +42,11 @@ class TestRailsAutolink < Minitest::Test
     link3_result = generate_result(link3_raw)
     assert_equal link3_result, auto_link(link3_raw)
     assert_equal "{link: #{link3_result}}", auto_link("{link: #{link3_raw}}")
+
+    link4_raw = 'http://en.wikipedia.org/wiki/Sprite_{computer_graphics}'
+    link4_result = generate_result(link4_raw)
+    assert_equal link4_result, auto_link(link4_raw)
+    assert_equal "&lt;link: #{link4_result}&gt;", auto_link("&lt;link: #{link4_raw}&gt;")
   end
 
   def test_auto_link_with_options_hash


### PR DESCRIPTION
This PR resolves an issue where a trailing `&gt;` would be included in the URL.

**Before**
`&lt;http://example.com&gt;` → &lt;[http://example.com&gt;](http://example.com&gt;) 

**After**
`&lt;http://example.com&gt;` → &lt;[http://example.com](http://example.com)&gt;

An example of `<>` being used to wrap URLs is when Gmail includes an auto-generated text part of a forwarded email by stripping the HTML and wrapping link URLs in `<>`.

The existing behaviour happens because we identify a URL by looking for a scheme and assume the URL continues until we encounter a small include list of characters (e.g white spaces and quotes).`&gt;` was not included there (and we can't use `&` as a stop character as it's allowed in URLs).